### PR TITLE
localise $_

### DIFF
--- a/lib/Bio/Restriction/Enzyme.pm
+++ b/lib/Bio/Restriction/Enzyme.pm
@@ -962,7 +962,7 @@ of the 4 nucleotides has an effective length of 1 - log(n) / log(4).
 
 sub cutter {
     my ($self)=@_;
-    $_ = uc $self->string;
+    local $_ = uc $self->string;
 
     my $cutter = tr/[ATGC]//d;
     my $count =  tr/[MRWSYK]//d;


### PR DESCRIPTION
Implementing multiple filters as below results in a fatal error.

```perl
# Can't locate object method "type" via package "NNNNNN" ...
@enzymes = grep { $_->cutter == 6 && $_->type eq 'II' } $collection->enzymes;
```

This PR localises `$_` so it no longer gets overridden.